### PR TITLE
fix: issue 44 so rescaling multiple layers works

### DIFF
--- a/js/sigplot.js
+++ b/js/sigplot.js
@@ -8486,10 +8486,14 @@
                 }
                 if (noxmin) {
                     xmin = Gx.lyr[n].xmin;
+                } else {
+                    xmin = xxmin;
                 }
 
                 if (noxmax) {
                     xmax = Gx.lyr[n].xmax;
+                } else {
+                    xmax = xxmax;
                 }
 
                 if (Gx.xlab !== Gx.lyr[n].xlab) {


### PR DESCRIPTION
The `scale_base` method neglected to reset xmin/xmax when checking
layers beyond the first layer.