### PR TITLE
new: Add ability to set plot note (fix #30)

### DIFF
--- a/js/sigplot.js
+++ b/js/sigplot.js
@@ -6748,7 +6748,7 @@
         }
 
         Gx.xdata = false;
-        Gx.note = o.note ? o.note : "";
+        Gx.note = o.note || "";
         Gx.hold = 0;
         Gx.always_show_marker = o.always_show_marker || false;
 

--- a/js/sigplot.js
+++ b/js/sigplot.js
@@ -6748,7 +6748,7 @@
         }
 
         Gx.xdata = false;
-        Gx.note = "";
+        Gx.note = o.note ? o.note : "";
         Gx.hold = 0;
         Gx.always_show_marker = o.always_show_marker || false;
 
@@ -7342,6 +7342,9 @@
      */
     function form_plotnote(plot) {
         var Gx = plot._Gx;
+        if (Gx.note) {
+            return;
+        }
         if (Gx.HCB.length === 0) {
             Gx.note = "";
         } else if (Gx.HCB[0].plotnote === undefined) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -6134,12 +6134,16 @@ interactiveTest('SP file raster', 'Do you see a plot that looks like a checkerbo
 });
 interactiveTest('Plot Note', 'Do you see the plot note saying "Test Note"?', function(assert) {
     var container = document.getElementById('plot');
-    var plot = new sigplot.Plot(container, {note: 'Test Note'});
+    var plot = new sigplot.Plot(container, {
+        note: 'Test Note'
+    });
     assert.notEqual(plot, null);
 });
 interactiveTest('Plot Note with data', 'Do you see the plot note saying "Test Note"?', function(assert) {
     var container = document.getElementById('plot');
-    var plot = new sigplot.Plot(container, {note: 'Test Note'});
+    var plot = new sigplot.Plot(container, {
+        note: 'Test Note'
+    });
     assert.notEqual(plot, null);
     plot.overlay_href("dat/scalarpacked.tmp", null, {
         subsize: 64,
@@ -6150,5 +6154,7 @@ interactiveTest('Plot Note Change Settings', 'Do you see the plot note saying "T
     var container = document.getElementById('plot');
     var plot = new sigplot.Plot(container, {});
     assert.notEqual(plot, null);
-    plot.change_settings({note: 'Test Note'});
+    plot.change_settings({
+        note: 'Test Note'
+    });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -6132,3 +6132,23 @@ interactiveTest('SP file raster', 'Do you see a plot that looks like a checkerbo
         layerType: "2D"
     });
 });
+interactiveTest('Plot Note', 'Do you see the plot note saying "Test Note"?', function(assert) {
+    var container = document.getElementById('plot');
+    var plot = new sigplot.Plot(container, {note: 'Test Note'});
+    assert.notEqual(plot, null);
+});
+interactiveTest('Plot Note with data', 'Do you see the plot note saying "Test Note"?', function(assert) {
+    var container = document.getElementById('plot');
+    var plot = new sigplot.Plot(container, {note: 'Test Note'});
+    assert.notEqual(plot, null);
+    plot.overlay_href("dat/scalarpacked.tmp", null, {
+        subsize: 64,
+        layerType: "2D"
+    });
+});
+interactiveTest('Plot Note Change Settings', 'Do you see the plot note saying "Test Note"?', function(assert) {
+    var container = document.getElementById('plot');
+    var plot = new sigplot.Plot(container, {});
+    assert.notEqual(plot, null);
+    plot.change_settings({note: 'Test Note'});
+});


### PR DESCRIPTION
This also includes tests for changing plot note in change_settings and plot_init.

This addresses #30.