### PR TITLE
Feat raster downscale

### DIFF
--- a/js/ColorMap.js
+++ b/js/ColorMap.js
@@ -173,14 +173,24 @@
              } : null;
          },
          getColor: function(number) {
-             var n = (number - this._low) * this._fscale;
-             var colorindex = ~~n; //make int fastest method
-             if (colorindex > this.map.length - 1) {
-                 colorindex = this.map.length - 1;
-             } else if (colorindex < 0) {
-                 colorindex = 0;
-             }
+             var colorindex = this.getColorIndex(number);
              return this.map[colorindex];
+         },
+         getColorByIndex: function(colorindex) {
+            return this.map[colorindex];
+         },
+         getColorIndex: function(number) {
+            var n = (number - this._low) * this._fscale;
+            var colorindex = ~~n; //make int fastest method
+            if (colorindex > this.map.length - 1) {
+                colorindex = this.map.length - 1;
+            } else if (colorindex < 0) {
+                colorindex = 0;
+            }
+            return colorindex;
+         },
+         getNColors : function() {
+             return this.map.length;
          },
          setRange: function(low, high) {
              // only recalculate if a value has changed

--- a/js/sigplot.js
+++ b/js/sigplot.js
@@ -6719,6 +6719,7 @@
         Gx.ydiv = o.ydiv === undefined ? 5 : o.ydiv;
 
         Gx.xcompression = o.xcmp || 0;
+        Gx.rasterDownscale = o.downscale || 0;
         Gx.rasterSmoothing = o.smoothing || false;
 
         Mx.origin = 1;

--- a/js/sigplot.layer2d.js
+++ b/js/sigplot.layer2d.js
@@ -415,9 +415,6 @@
                 (settings.autoz !== undefined)) {
                 this.img = undefined;
             }
-            if (settings.cmap !== undefined) {
-                this.img = undefined;
-            }
             if ((settings.drawmode !== undefined) || (settings.xmin !== undefined) ||
                 (settings.xmax !== undefined) || (settings.xdelta !== undefined) ||
                 (settings.xstart !== undefined)) {
@@ -978,7 +975,7 @@
             Gx.ye = Math.max(1, Math.round(ry));
 
             // we might need to prep in certian situations
-            if ((!this.img) || (!this.buf) || (Gx.cmode !== this.img.cmode) || (Gx.cmap !== this.img.cmap) || (Mx.origin !== this.img.origin)) {
+            if ((!this.img) || (!this.buf) || (Gx.cmode !== this.img.cmode) || (Mx.origin !== this.img.origin)) {
                 this.prep(xmin, xmax);
             }
 

--- a/js/sigplot.layer2d.js
+++ b/js/sigplot.layer2d.js
@@ -66,6 +66,7 @@
         this.preferred_origin = 4;
         this.opacity = 1;
         this.xcompression = plot._Gx.xcompression; // default is Gx.xcompression
+        this.downscale = plot._Gx.rasterDownscale;
 
         // LPB is kinda odd right now, since we read the entire file into memory anyways...
         // given that often we are loading from an HREF so there is no downside to this...
@@ -488,6 +489,10 @@
             if (settings.name !== undefined) {
                 this.name = settings.name;
             }
+
+            if (settings.downscale !== undefined) {
+                this.downscale = settings.downscale;
+            }
         },
 
         reload: function(data, hdrmod) {
@@ -547,16 +552,17 @@
                     delete hdrmod["timestamp"];
                 }
 
-                // If the subsize changes, we need to invalidate the buffer
+                // If the subsize changes, we need to invalidate the buffer and image
                 if ((hdrmod.subsize) && (hdrmod.subsize !== this.hcb.subsize)) {
                     this.hcb.subsize = hdrmod.subsize;
                     if (this.hcb.pipe && !Gx.p_cuts) {
                         this.buf = this.hcb.createArray(null, 0, this.hcb.subsize * this.hcb.spa);
                         this.zbuf = new m.PointArray(this.hcb.subsize);
-
+                        this.img = undefined;
                     } else {
                         this.buf = this.hcb.createArray(null, 0, this.lps * this.hcb.subsize * this.hcb.spa);
                         this.zbuf = new m.PointArray(this.lps * this.hcb.subsize);
+                        this.img = undefined;
                     }
                     rescale = true;
                 }
@@ -978,7 +984,7 @@
 
             // if there is an image, render it
             if (this.img) {
-                mx.draw_image(Mx, this.img, this.xmin, this.ymin, this.xmax, this.ymax, this.opacity, Gx.rasterSmoothing);
+                mx.draw_image(Mx, this.img, this.xmin, this.ymin, this.xmax, this.ymax, this.opacity, Gx.rasterSmoothing, this.downscale);
             }
 
             // render the scrolling pipe line

--- a/test/tests.js
+++ b/test/tests.js
@@ -6168,3 +6168,197 @@ interactiveTest('Plot Note Change Settings', 'Do you see the plot note saying "T
         note: 'Test Note'
     });
 });
+interactiveTest('Raster downscale max', 'Do you see two red lines in the middle?', function(assert) {
+    var container = document.getElementById('plot');
+    var plot = new sigplot.Plot(container, {});
+    assert.notEqual(plot, null);
+
+    plot.change_settings({
+        cmode: 'LO',
+        autol: 5
+    });
+
+    plot.overlay_pipe({
+        type: 2000,
+        subsize: 0,
+        file_name: "random",
+        xstart: null,
+        xdelta: null
+    }, {
+        downscale: "max"
+    });
+
+    var hdl = window.setInterval(function() {
+        var random = [];
+        var framesize = 32768;
+        for (var i = 0; i < framesize; i += 1) {
+            random.push(Math.random() + 100);
+        }
+        random[500] = 1;
+        random[15990] = 1000;
+        random[15991] = 100;
+        random[15992] = 100;
+        random[15993] = 100;
+        random[15995] = 100;
+        random[15996] = 100;
+        random[15997] = 100;
+        random[15998] = 100;
+        random[15999] = 1000;
+        random[16000] = 1000;
+        random[16001] = 1000;
+        random[16002] = 1000;
+        random[18000] = 1000;
+
+        plot.push(0, random, {
+            subsize: framesize,
+            xstart: 5e6,
+            xdelta: 10
+        });
+    }, 300);
+});
+interactiveTest('Raster downscale min', 'Do you see one black line on the left?', function(assert) {
+    var container = document.getElementById('plot');
+    var plot = new sigplot.Plot(container, {});
+    assert.notEqual(plot, null);
+
+    plot.change_settings({
+        cmode: 'LO',
+        autol: 5
+    });
+
+    plot.overlay_pipe({
+        type: 2000,
+        subsize: 0,
+        file_name: "random",
+        xstart: null,
+        xdelta: null
+    }, {
+        downscale: "min"
+    });
+
+    var hdl = window.setInterval(function() {
+        var random = [];
+        var framesize = 32768;
+        for (var i = 0; i < framesize; i += 1) {
+            random.push(Math.random() + 50);
+        }
+        random[500] = 1;
+        random[15990] = 1000;
+        random[15991] = 100;
+        random[15992] = 100;
+        random[15993] = 100;
+        random[15995] = 100;
+        random[15996] = 100;
+        random[15997] = 100;
+        random[15998] = 100;
+        random[15999] = 1000;
+        random[16000] = 1000;
+        random[16001] = 1000;
+        random[16002] = 1000;
+        random[18000] = 1000;
+
+        plot.push(0, random, {
+            subsize: framesize,
+            xstart: 5e6,
+            xdelta: 10
+        });
+    }, 300);
+});
+interactiveTest('Raster downscale minmax', 'Do you see one black line on the left and two red lines in the middle?', function(assert) {
+    var container = document.getElementById('plot');
+    var plot = new sigplot.Plot(container, {});
+    assert.notEqual(plot, null);
+
+    plot.change_settings({
+        cmode: 'LO',
+        autol: 5
+    });
+
+    plot.overlay_pipe({
+        type: 2000,
+        subsize: 0,
+        file_name: "random",
+        xstart: null,
+        xdelta: null
+    }, {
+        downscale: "minmax"
+    });
+
+    var hdl = window.setInterval(function() {
+        var random = [];
+        var framesize = 32768;
+        for (var i = 0; i < framesize; i += 1) {
+            random.push(Math.random() + 50);
+        }
+        random[500] = 1;
+        random[15990] = 1000;
+        random[15991] = 100;
+        random[15992] = 100;
+        random[15993] = 100;
+        random[15995] = 100;
+        random[15996] = 100;
+        random[15997] = 100;
+        random[15998] = 100;
+        random[15999] = 1000;
+        random[16000] = 1000;
+        random[16001] = 1000;
+        random[16002] = 1000;
+        random[18000] = 1000;
+
+        plot.push(0, random, {
+            subsize: framesize,
+            xstart: 5e6,
+            xdelta: 10
+        });
+
+    }, 300);
+});
+interactiveTest('Raster change settings after overlay', 'Do you see two red lines in the middle?', function(assert) {
+    var container = document.getElementById('plot');
+    var plot = new sigplot.Plot(container, {});
+    assert.notEqual(plot, null);
+
+    plot.overlay_pipe({
+        type: 2000,
+        subsize: 0,
+        file_name: "random",
+        xstart: null,
+        xdelta: null
+    }, {
+        downscale: "max"
+    });
+
+    plot.change_settings({
+        cmode: 'LO'
+        //autol: 5
+    });
+
+    var hdl = window.setInterval(function() {
+        var random = [];
+        var framesize = 32768;
+        for (var i = 0; i < framesize; i += 1) {
+            random.push(Math.random() + 100);
+        }
+        random[500] = 1;
+        random[15990] = 1000;
+        random[15991] = 100;
+        random[15992] = 100;
+        random[15993] = 100;
+        random[15995] = 100;
+        random[15996] = 100;
+        random[15997] = 100;
+        random[15998] = 100;
+        random[15999] = 1000;
+        random[16000] = 1000;
+        random[16001] = 1000;
+        random[16002] = 1000;
+        random[18000] = 1000;
+
+        plot.push(0, random, {
+            subsize: framesize,
+            xstart: 5e6,
+            xdelta: 10
+        });
+
+    }, 300);
+});


### PR DESCRIPTION
Provide a 'raster' downscale mode that ensures that single pixel features can be rendered.  This is similar to xcompression, but occurs via `scaleImage` so that if you zoom you can see the full details.

This required a change in how the internal 'image' buffer was stored.  Originally it stored RGBA values and now it stores the color index values.  This has the side benefit of also allows the colormap to be changed dynamically without throwing away the old values.