### PR TITLE
[WIP] Adding RDP Compression

### DIFF
--- a/js/mx.js
+++ b/js/mx.js
@@ -5352,6 +5352,40 @@
     mx.update_image_row = function(Mx, buf, data, row, zmin, zmax, xcompression) {
         var imgd = new Uint32Array(buf, row * buf.width * 4, buf.width);
 
+        
+        // special case xcompression type 6 should run outside of for loop
+        if (data && xcompression === 6) {
+            console.log('INSIDE OUR SPECIAL CASE!');
+            
+            let formattedData = [];
+            let simplifiedData = [];
+            let reformattedData = [];
+
+            console.log('data before simplify: ', data);
+
+            // format data with x and y properties
+            for (var index = 0; index < data.length; index++) {
+                value = data[index];
+                formattedData.push({ ['x']: index, ['y']: value });
+            }
+
+            console.log('our formatted data! ', formattedData);
+
+            // run formatted data through simplify js
+            simplifiedData = simplify(formattedData, 1, false);
+
+            // reformat array back to original
+            reformattedData = simplifiedData.map((item) => {
+                return item.y
+            });
+            
+            // set data equal to reformatted, simplified data
+            data = reformattedData;
+
+            console.log('data after simplify: ', data);
+        }
+
+
         Mx.pixel.setRange(zmin, zmax);
 
         var xc = Math.max(1, data.length / buf.width);
@@ -5360,25 +5394,33 @@
             var value = data[didx];
             if (xc > 1) {
                 if (xcompression === 1) { // average
+                    console.log('WENT INTO XCOMPRESSION 1!!!!!!!!!!!!!!!!!!!!!!!');
                     for (var j = 1; j < xc; j++) {
                         value += data[didx + j];
                     }
                     value = (value / xc);
                 } else if (xcompression === 2) { // min
+                    console.log('WENT INTO XCOMPRESSION 2!!!!!!!!!!!!!!!!!!!!!!!');
                     for (var j = 1; j < xc; j++) {
                         value = Math.min(value, data[didx + j]);
                     }
                 } else if (xcompression === 3) { // max
+                    console.log('WENT INTO XCOMPRESSION 3!!!!!!!!!!!!!!!!!!!!!!!');
                     for (var j = 1; j < xc; j++) {
                         value = Math.max(value, data[didx + j]);
                     }
                 } else if (xcompression === 4) { // first
+                    console.log('WENT INTO XCOMPRESSION 4!!!!!!!!!!!!!!!!!!!!!!!');
                     value = data[i];
                 } else if (xcompression === 5) { // max abs
+                    console.log('WENT INTO XCOMPRESSION 5!!!!!!!!!!!!!!!!!!!!!!!');
                     for (var j = 1; j < xc; j++) {
                         value = Math.max(Math.abs(value), Math.abs(data[didx + j]));
                     }
+                } else if (xcompression === 6) { // RDP Compression / Decimation
+                    console.log('WENT INTO XCOMPRESSION 6!!!!!!!!!!!!!!!!!!!!!!!');
                 }
+
             }
             var colorIdx = Mx.pixel.getColorIndex(value);
             imgd[i] = colorIdx;

--- a/js/mx.js
+++ b/js/mx.js
@@ -5352,24 +5352,18 @@
     mx.update_image_row = function(Mx, buf, data, row, zmin, zmax, xcompression) {
         var imgd = new Uint32Array(buf, row * buf.width * 4, buf.width);
 
-        
         // special case xcompression type 6 should run outside of for loop
         if (data && xcompression === 6) {
-            console.log('INSIDE OUR SPECIAL CASE!');
             
             let formattedData = [];
             let simplifiedData = [];
             let reformattedData = [];
-
-            console.log('data before simplify: ', data);
 
             // format data with x and y properties
             for (var index = 0; index < data.length; index++) {
                 value = data[index];
                 formattedData.push({ ['x']: index, ['y']: value });
             }
-
-            console.log('our formatted data! ', formattedData);
 
             // run formatted data through simplify js
             simplifiedData = simplify(formattedData, 1, false);
@@ -5381,8 +5375,6 @@
             
             // set data equal to reformatted, simplified data
             data = reformattedData;
-
-            console.log('data after simplify: ', data);
         }
 
 
@@ -5394,31 +5386,24 @@
             var value = data[didx];
             if (xc > 1) {
                 if (xcompression === 1) { // average
-                    console.log('WENT INTO XCOMPRESSION 1!!!!!!!!!!!!!!!!!!!!!!!');
                     for (var j = 1; j < xc; j++) {
                         value += data[didx + j];
                     }
                     value = (value / xc);
                 } else if (xcompression === 2) { // min
-                    console.log('WENT INTO XCOMPRESSION 2!!!!!!!!!!!!!!!!!!!!!!!');
                     for (var j = 1; j < xc; j++) {
                         value = Math.min(value, data[didx + j]);
                     }
                 } else if (xcompression === 3) { // max
-                    console.log('WENT INTO XCOMPRESSION 3!!!!!!!!!!!!!!!!!!!!!!!');
                     for (var j = 1; j < xc; j++) {
                         value = Math.max(value, data[didx + j]);
                     }
                 } else if (xcompression === 4) { // first
-                    console.log('WENT INTO XCOMPRESSION 4!!!!!!!!!!!!!!!!!!!!!!!');
                     value = data[i];
                 } else if (xcompression === 5) { // max abs
-                    console.log('WENT INTO XCOMPRESSION 5!!!!!!!!!!!!!!!!!!!!!!!');
                     for (var j = 1; j < xc; j++) {
                         value = Math.max(Math.abs(value), Math.abs(data[didx + j]));
                     }
-                } else if (xcompression === 6) { // RDP Compression / Decimation
-                    console.log('WENT INTO XCOMPRESSION 6!!!!!!!!!!!!!!!!!!!!!!!');
                 }
 
             }

--- a/js/sigplot.js
+++ b/js/sigplot.js
@@ -5001,7 +5001,6 @@
                     text: "XLABel...",
                     handler: function() {
                         var validator = function(value) {
-                            console.log("The value is " + value);
                             var isValid = mx.intValidator(value);
                             return isValid;
                         };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "loglevel": "^1.4.1",
+    "simplify-js": "^1.2.3",
     "spin": "0.0.1",
     "tinycolor2": "^1.4.1",
     "travis": "^0.1.1"

--- a/test/test.html
+++ b/test/test.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<title>WebSigPlot Unit Test</title>
 	<link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css">
-        <!-- show all tests, even if they haven't run yet --!>
+        <!-- show all tests, even if they haven't run yet -->
         <style>
             #qunit-tests > li {
               display: initial;
@@ -17,6 +17,7 @@
 	<div id="qunit-fixture"></div>
 	<script src="../node_modules/qunitjs/qunit/qunit.js"></script>
 	<script src="../node_modules/qunit-assert-close/qunit-assert-close.js"></script>
+	<script src="../node_modules/simplify-js/simplify.js"></script>
         <script>
         // always run tests in-order
         QUnit.config.reorder = false;

--- a/test/tests.js
+++ b/test/tests.js
@@ -1963,6 +1963,31 @@ QUnit.module('sigplot-interactive', {
         }
     }
 });
+interactiveTest('xcomp:6 (rdp)', 'This is our rdp xcmp 6 test', function(assert) {
+
+    var bfr = new sigplot.bluefile.BlueFileReader();
+    bfr.read_http("dat/sin.tmp", function(hdr) {
+        console.log('here is hdr ', hdr);
+        let dataPoints = hdr.dview;
+        console.log('here are the values: ', dataPoints);
+
+        var container = document.getElementById('plot');
+        var plot = new sigplot.Plot(container, {
+            xcmp: 6
+        });
+
+        plot.overlay_pipe({
+            type: 2000,
+            subsize: 16384
+        });
+        var cnt = 0;
+        ifixture.interval = window.setInterval(function() {
+            cnt = cnt + 1;
+            plot.push(0, dataPoints);
+        }, 100);
+    });
+});
+
 interactiveTest('sigplot empty', 'Do you see an empty plot scaled from -1 to 1 on both axis?', function(assert) {
     var container = document.getElementById('plot');
     assert.equal(container.childNodes.length, 0);


### PR DESCRIPTION
This adds RDP Compression via the Simplify.js npm package found here:
https://github.com/mourner/simplify-js

and can be used like this:

```
var container = document.getElementById('plot');
        var plot = new sigplot.Plot(container, {
            xcmp: 6
        });
```

Use of this compression is also implemented in the first test to run within the tests directory