### PR TITLE
Fix changing zmin and zmax from menu

### DIFF
--- a/js/sigplot.js
+++ b/js/sigplot.js
@@ -4738,14 +4738,15 @@
                                 "Z Axis Max:",
                                 mx.floatValidator,
                                 function(finalValue) {
-                                    if (parseFloat(finalValue) !== Gx.zmax) {
+                                    var floatFinalValue = parseFloat(finalValue);
+                                    if (floatFinalValue !== Gx.zmax) {
                                         // Only update if different
                                         // value
                                         if (finalValue === "") {
-                                            finalValue = 0;
+                                            floatFinalValue = 0;
                                         }
                                         plot.change_settings({
-                                            zmax: finalValue
+                                            zmax: floatFinalValue
                                         });
                                     }
                                 }, Gx.zmax,
@@ -4757,12 +4758,13 @@
                             "Z Axis Min:",
                             mx.floatValidator,
                             function(finalValue) {
-                                if (parseFloat(finalValue) !== Gx.zmin) {
+                                var floatFinalValue = parseFloat(finalValue);
+                                if (floatFinalValue !== Gx.zmin) {
                                     if (finalValue === "") {
-                                        finalValue = 0;
+                                        floatFinalValue = 0;
                                     }
                                     plot.change_settings({
-                                        zmin: finalValue
+                                        zmin: floatFinalValue
                                     });
                                 }
                             }, Gx.zmin, undefined,

--- a/js/sigplot.js
+++ b/js/sigplot.js
@@ -1359,7 +1359,7 @@
                                     Gx.x_pop_now = false;
                                 }
                             } else if ((Gx.xyKeys !== "disable") && (Gx.lyr[0].hcb["class"] === 2)) {
-                                // show xCut if xyKeys aren't disabled and the first layer is 
+                                // show xCut if xyKeys aren't disabled and the first layer is
                                 // type 2000 and y-cut isn't currently enabled (we already checked
                                 // that x_cut above)
                                 if (!Gx.y_cut_press_on) {
@@ -1384,7 +1384,7 @@
                                     Gx.y_pop_now = false;
                                 }
                             } else if ((Gx.xyKeys !== "disable") && (Gx.lyr[0].hcb["class"] === 2)) {
-                                // show xCut if xyKeys aren't disabled and the first layer is 
+                                // show xCut if xyKeys aren't disabled and the first layer is
                                 // type 2000 and y-cut isn't currently enabled (we already checked
                                 // that y_cut above)
                                 if (!Gx.x_cut_press_on) {
@@ -1652,7 +1652,6 @@
          * @param {Boolean}
          *            settings.p_cuts true displays p_cuts on a 2D plot
          */
-
         change_settings: function(settings) {
             var Gx = this._Gx;
             var Mx = this._Mx;


### PR DESCRIPTION
We ran into a situation where changing zmin and zmax from the menu yielded different results from calling change_settings outright.

This is because the menu wasn't converting the value to a float, but rather leaving it as a string. So all `mx.create_image` calls in `prep` in [sigplot.layer2d.js#793]() were concatenating (in some cases) a 0 to the end:

```js
this.img = mx.create_image(Mx,
    this.zbuf,
    this.hcb.subsize,
    xsize,
    this.lps,
    Gx.zmin + Gx.zoff,  // <-- here
    Gx.zmax + Gx.zoff,  // <-- here
    this.xcompression);
```

The only reason this worked in general is because of JS' weak typing -- i.e.,
- `Gx.zmin + Gx.zoff`, where `Gx.zmin` is a string and `Gx.zoff` is a number, concatenates the number to the string -- e.g., `"25" + 0 == "250"`. 
- In `mx.create_image`, `zmin`/`zmax` is passed into `Mx.pixel.setRange` in ColorMap.js, which subtracts `zmax - zmin`. In JavaScript, `"250" - 0` and `"250" - "0"` both yield the number `250`.